### PR TITLE
Support for millisecond-precise time inputs (currently only supports seconds-precise time inputs)

### DIFF
--- a/src/gstime/jday.js
+++ b/src/gstime/jday.js
@@ -1,7 +1,7 @@
 define([], function() {
     'use strict';
 
-    return function(year, mon, day, hr, minute, sec) {
+    return function(year, mon, day, hr, minute, sec, msec) {
         if (year instanceof Date) {
             var date = year;
             year = date.getUTCFullYear();
@@ -10,13 +10,16 @@ define([], function() {
             hr = date.getUTCHours();
             minute = date.getUTCMinutes();
             sec = date.getUTCSeconds();
+            msec = date.getUTCMilliseconds();
         }
+        
+        msec = msec || 0;
 
         return (367.0 * year -
         Math.floor((7 * (year + Math.floor((mon + 9) / 12.0))) * 0.25) +
         Math.floor( 275 * mon / 9.0 ) +
         day + 1721013.5 +
-        ((sec / 60.0 + minute) / 60.0 + hr) / 24.0  //  ut in days
+        ((msec / 60000 + sec / 60.0 + minute) / 60.0 + hr) / 24.0  //  ut in days
             //#  - 0.5*sgn(100.0*year + mon - 190002.5) + 0.5;
         );
     };


### PR DESCRIPTION
Previously the generated lat/lon were seconds-precise.  This small tweak takes into account milliseconds where present (falling back on 0 milliseconds), which allows us to animate smoothly.