### PR TITLE
Include deg2rad constant in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ var positionAndVelocity = satellite.sgp4(satrec, time);
 ## Sample Usage
     
 ```js
+var deg2rad = 0.017453292519943295; // (angle / 180) * Math.PI;
+
 // Sample TLE
 var tleLine1 = '1 25544U 98067A   13149.87225694  .00009369  00000-0  16828-3 0  9031',
     tleLine2 = '2 25544 051.6485 199.1576 0010128 012.7275 352.5669 15.50581403831869';


### PR DESCRIPTION
This variable is referenced when initializing the `observerGd` object in the example code.