### PR TITLE
Fix various typos in code

### DIFF
--- a/src/propagation/sgp4.js
+++ b/src/propagation/sgp4.js
@@ -277,7 +277,7 @@ export default function sgp4(satrec, tsince) {
       nodep,
       argpp,
       mp,
-      opsmode: satrec.operationmod,
+      opsmode: satrec.operationmode,
     };
 
     const dpperResult = dpper(satrec, dpperParameters);

--- a/src/propagation/sgp4init.js
+++ b/src/propagation/sgp4init.js
@@ -275,7 +275,7 @@ export default function sgp4init(satrec, options) {
 
   if (omeosq >= 0.0 || satrec.no >= 0.0) {
     satrec.isimp = 0;
-    if ((rp < 220.0 / earthRadius) + 1.0) {
+    if (rp < (220.0 / earthRadius + 1.0)) {
       satrec.isimp = 1;
     }
     sfour = ss;


### PR DESCRIPTION
I stumbled upon these when I unsuccessfully tried to port the library to TypeScript. These seem like accidental typos when porting from Python to JS.