### PR TITLE
Add TypeScript Definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 4.0.1 (2020-08-25)
+
+- TypeScript support is added via new TypeScript definitions file.
+
 ### 4.0.0 (2020-01-21)
 
 - Node.js 12 support is added. Node.js 6 and Node.js 8 support is dropped (breaking change).
@@ -9,7 +13,7 @@
 ### 3.0.1 (2019-03-14)
 
 - Unnecessary calculations in `sgp4` function are reduced (#47).
-- `vkmpersec` calculation is moved to constants (#50). 
+- `vkmpersec` calculation is moved to constants (#50).
 - `degreesToRadians` function is used in docs instead of `deg2rad` constant (#53).
 - Typos' fixes (#54).
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "SGP4/SDP4 calculation library",
   "main": "lib/index.js",
   "jsnext:main": "dist/satellite.es.js",
+  "types": "types/index.d.ts",
   "module": "dist/satellite.es.js",
   "scripts": {
     "build": "rimraf lib dist && npm run transpile && npm run dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satellite.js",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "SGP4/SDP4 calculation library",
   "main": "lib/index.js",
   "jsnext:main": "dist/satellite.es.js",

--- a/src/io.js
+++ b/src/io.js
@@ -116,7 +116,6 @@ export default function twoline2satrec(longstr1, longstr2) {
   satrec.alta = (satrec.a * (1.0 + satrec.ecco)) - 1.0;
   satrec.altp = (satrec.a * (1.0 - satrec.ecco)) - 1.0;
 
-
   // ----------------------------------------------------------------
   // find sgp4epoch time of element set
   // remember that sgp4 uses units of days from 0 jan 1950 (sgp4epoch)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,199 @@
+declare module 'satellite.js' {
+  /**
+   * Satellite record containing description of orbit.
+   */
+  export interface SatRec {
+    /**
+     * Unique satellite number given in the TLE file.
+     */
+    satnum: string;
+    /**
+     * Full four-digit year of this element set's epoch moment.
+     */
+    epochyr: number;
+    /**
+     * Fractional days into the year of the epoch moment.
+     */
+    epochdays: number;
+    /**
+     * Julian date of the epoch (computed from epochyr and epochdays).
+     */
+    jdsatepoch: number;
+    /**
+     * First time derivative of the mean motion (ignored by SGP4).
+     */
+    ndot: number;
+    /**
+     * Second time derivative of the mean motion (ignored by SGP4).
+     */
+    nddot: number;
+    /**
+     * Ballistic drag coefficient B* in inverse earth radii.
+     */
+    bstar: number;
+    /**
+     * Inclination in radians.
+     */
+    inclo: number;
+    /**
+     * Right ascension of ascending node in radians.
+     */
+    nodeo: number;
+    /**
+     * Eccentricity.
+     */
+    ecco: number;
+    /**
+     * Argument of perigee in radians.
+     */
+    argpo: number;
+    /**
+     * Mean anomaly in radians.
+     */
+    mo: number;
+    /**
+     * Mean motion in radians per minute.
+     */
+    no: number;
+  }
+
+  /**
+   * Initialize a satellite record
+   */
+  export function twoline2satrec(tleLine1: string, tleLine2: string): SatRec;
+
+  /**
+   * Coordinate frame Earth Centered Inertial (ECI)
+   * https://en.wikipedia.org/wiki/Earth-centered_inertial
+   */
+  export interface EciVec3<T> {
+    x: T;
+    y: T;
+    z: T;
+  }
+
+  /**
+   * Coordinate frame Earth Centered Fixed (ECF)
+   * https://en.wikipedia.org/wiki/ECEF
+   */
+  export interface EcfVec3<T> {
+    x: T;
+    y: T;
+    z: T;
+  }
+
+  /**
+   * Type alias documents units are kilometer (km)
+   */
+  export type Kilometer = number;
+
+  /**
+   * Type alias documents units are kilometer per second (km/s)
+   */
+  export type KilometerPerSecond = number;
+
+  /**
+   * The position_velocity result is a key-value pair of ECI coordinates.
+   * These are the base results from which all other coordinates are derived.
+   */
+  export interface PositionAndVelocity {
+    position: EciVec3<Kilometer>;
+    velocity: EciVec3<KilometerPerSecond>;
+  }
+
+  /**
+   * Propagate satellite using time since epoch (in minutes).
+   */
+  export function sgp4(satrec: SatRec, timeSinceTleEpochMinutes: number): PositionAndVelocity;
+
+  /**
+   * Propagate satellite using time as JavaScript Date.
+   */
+  export function propagate(satrec: SatRec, date: Date): PositionAndVelocity;
+
+  /**
+   * Type alias documents units are radians
+   */
+  export type Radians = number;
+
+  /**
+   * Type alias documents units are degrees
+   */
+  export type Degrees = number;
+
+  /**
+   * Convert number in degrees to number in radians
+   * @param value Number to convert
+   */
+  export function degreesToRadians(value: Degrees): Radians;
+
+  /**
+   * https://en.wikipedia.org/wiki/Geographic_coordinate_system#Latitude_and_longitude
+   */
+  export interface GeodeticLocation {
+    longitude: Radians;
+    latitude: Radians;
+    height: Kilometer;
+  }
+
+  /**
+   * You will need GMST for some of the coordinate transforms.
+   * GMST - Greenwich Mean Sidereal Time
+   * http://en.wikipedia.org/wiki/Sidereal_time#Definition
+   */
+  export type GMSTime = number;
+
+  /**
+   * Convert a date time to GMST
+   * @param date Time to convert
+   */
+  export function gstime(date: Date): GMSTime;
+
+  /**
+   * Convert ECI to ECF. Units are not modified.
+   */
+  export function eciToEcf<T>(positionEci: EciVec3<T>, gmst: GMSTime): EcfVec3<T>;
+
+  /**
+   * Convert geodetic location to ECF
+   */
+  export function geodeticToEcf(observerGd: GeodeticLocation): EcfVec3<Kilometer>;
+
+  /**
+   * Convert ECI to geodetic location
+   */
+  export function eciToGeodetic(positionEci: EciVec3<Kilometer>, gmst: GMSTime): GeodeticLocation;
+
+  /**
+   * https://en.wikipedia.org/wiki/Azimuth
+   */
+  export interface LookAngles {
+    azimuth: Radians;
+    elevation: Radians;
+    rangeSat: Kilometer;
+  }
+
+  /**
+   * Convert ECF to look angles
+   */
+  export function ecfToLookAngles(observerGd: GeodeticLocation, positionEcf: EcfVec3<Kilometer>): LookAngles;
+
+  /**
+   * Compute doppler factor between observer and satellite with position and velocity.
+   */
+  export function dopplerFactor(
+    observerCoordsEcf: EcfVec3<Kilometer>,
+    positionEcf: EcfVec3<Kilometer>,
+    velocityEcf: EcfVec3<KilometerPerSecond>
+  ): number;
+
+  /**
+   * Convert the longitude in RADIANS to DEGREES for pretty printing (appends "N", "S", "E", "W", etc).
+   */
+  export function degreesLong(longitude: Radians): string;
+
+  /**
+   * Convert the latitude in RADIANS to DEGREES for pretty printing (appends "N", "S", "E", "W", etc).
+   */
+  export function degreesLat(latitude: Radians): string;
+}


### PR DESCRIPTION
Hi, Thank you for the great library. I am trying to use satellite.js in TypeScript which requires type definitions for the TypeScript compiler. I got it working locally, but would like to share the definitions so others can use your library in TypeScript as well.

I followed the contribution directions, except that I had to fork instead of branch since I don't expect to have write access to your repository. 

I also updated the change log and version as directed by the contributions guide, but if that is something that you prefer to mange I can remove that from this pull request.

I can also attach my test file which may help you see how this can be used in TypeScript with Jest. The test file is just for reference since I did not add TypeScript to your package dependencies, since that seemed like too much of a change.
[satellite.test.ts.txt](https://github.com/shashwatak/satellite-js/files/5126441/satellite.test.ts.txt)

Let me know what you think.
Thanks, Kyle