### PR TITLE
Improve TypeScript definitions for handling propagation errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 4.1.2 (2020-10-13)
+
+- Expose `error` in TypeScript definition of `SatRec`.
+- Fix TypeScript definition for `PositionAndVelocity` to allow error handling.
+
 ### 4.1.1 (2020-09-15)
 
 - Fix TypeScript definition for `gstime` (#73).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satellite.js",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "SGP4/SDP4 calculation library",
   "main": "lib/index.js",
   "jsnext:main": "dist/satellite.es.js",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -55,6 +55,10 @@ declare module 'satellite.js' {
      * Mean motion in radians per minute.
      */
     no: number;
+    /**
+     * Error code indicating propagation failure type.
+     */
+    error: number;
   }
 
   /**
@@ -95,10 +99,11 @@ declare module 'satellite.js' {
   /**
    * The position_velocity result is a key-value pair of ECI coordinates.
    * These are the base results from which all other coordinates are derived.
+   * If there is an error the position and velocity will be false.
    */
   export interface PositionAndVelocity {
-    position: EciVec3<Kilometer>;
-    velocity: EciVec3<KilometerPerSecond>;
+    position: EciVec3<Kilometer>|boolean;
+    velocity: EciVec3<KilometerPerSecond>|boolean;
   }
 
   /**


### PR DESCRIPTION
Update TypeScript definitions to include SatRec.error and boolean
results for PositionAndVelocity. This allows handling of errors
when the propagator fails, for example when given a time too far
from the TLE epoch.
Update version, changelog.