### PR TITLE
Added function `json2satrec` in `io.js`

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -13,3 +13,4 @@ export const j3 = -0.00000253881;
 export const j4 = -0.00000165597;
 export const j3oj2 = j3 / j2;
 export const x2o3 = 2.0 / 3.0;
+export const xpdotp = 1440.0 / (2.0 * pi); // 229.1831180523293;

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,8 @@ import {
   ecfToLookAngles,
 } from './transforms';
 
+import { sunPos } from './sun';
+
 export {
   constants,
 
@@ -47,4 +49,7 @@ export {
   eciToEcf,
   ecfToEci,
   ecfToLookAngles,
+
+  // Sun Position
+  sunPos,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import * as constants from './constants';
 
 import { jday, invjday } from './ext';
-import twoline2satrec from './io';
+import { twoline2satrec, json2satrec} from './io';
 import { propagate, sgp4, gstime } from './propagation';
 
 import dopplerFactor from './dopplerFactor';
@@ -27,6 +27,7 @@ export {
   propagate,
   sgp4,
   twoline2satrec,
+  json2satrec,
 
   gstime,
   jday,

--- a/src/indexUmd.js
+++ b/src/indexUmd.js
@@ -1,7 +1,7 @@
 import * as constants from './constants';
 
 import { jday, invjday } from './ext';
-import twoline2satrec from './io';
+import { twoline2satrec, json2satrec} from './io';
 import { propagate, sgp4, gstime } from './propagation';
 
 import dopplerFactor from './dopplerFactor';
@@ -27,6 +27,7 @@ export default {
   propagate,
   sgp4,
   twoline2satrec,
+  json2satrec,
 
   gstime,
   jday,

--- a/src/io.js
+++ b/src/io.js
@@ -189,7 +189,7 @@ export function json2satrec(jsonobj, opsmode = 'i') {
   const satrec = {};
   satrec.error = 0;
 
-  satrec.satnum = jsonobj.NORAD_CAT_ID.toString().padStart(5, '0');
+  satrec.satnum = jsonobj.NORAD_CAT_ID.toString();
 
   const epoch = new Date(jsonobj.EPOCH + 'Z');
   const year = epoch.getUTCFullYear();

--- a/src/io.js
+++ b/src/io.js
@@ -162,46 +162,26 @@ export default function twoline2satrec(longstr1, longstr2) {
  *    propagates from -1440 to 1440 min from epoch and is useful when performing 
  *    entire catalog runs.
  *
- *  author        : david vallado                  719-573-2600    1 mar 2001
+ *  author        : Hariharan Vitaladevuni                   18 Aug 2023
  *
  *  inputs        :
  *    jsonobj     - OMM json data
- *    typerun     - type of run                    verification 'v', catalog 'c',
- *                                                 manual 'm'
- *    typeinput   - type of manual input           mfe 'm', epoch 'e', dayofyr 'd'
- *    opsmode     - mode of operation afspc or improved 'a', 'i'
- *    whichconst  - which set of constants to use  72, 84
+ *    opsmode     - mode of operation afspc or improved 'a', 'i'. Default: 'i'.
  *
  *  outputs       :
  *    satrec      - structure containing all the sgp4 satellite information
  *
  *  coupling      :
- *    getgravconst-
  *    days2mdhms  - conversion of days to month, day, hour, minute, second
  *    jday        - convert day month year hour minute second into julian date
  *    sgp4init    - initialize the sgp4 variables
  *
  *  references    :
+ *    https://celestrak.org/NORAD/documentation/gp-data-formats.php
  *    norad spacetrack report #3
  *    vallado, crawford, hujsak, kelso  2006
  --------------------------------------------------------------------------- */
-
-/**
- * Return a Satellite imported from OMM JSON format data.
- *
- * Provide the OMM JSON format data as `jsonobj`,
- * and select which standard set of gravitational constants you want
- * by providing `gravity_constants`:
- *
- * `sgp4.propagation.wgs72` - Standard WGS 72 model
- * `sgp4.propagation.wgs84` - More recent WGS 84 model
- * `sgp4.propagation.wgs72old` - Legacy support for old SGP4 behavior
- *
- * Normally, computations are made using letious recent improvements
- * to the algorithm.  If you want to turn some of these off and go
- * back into "afspc" mode, then set `afspc_mode` to `True`.
- */
-function json2satrec(jsonobj) {
+function json2satrec(jsonobj, opsmode='i') {
   const opsmode = 'i';
   const xpdotp = 1440.0 / (2.0 * pi); // 229.1831180523293;
   let year = 0;
@@ -231,12 +211,6 @@ function json2satrec(jsonobj) {
 
   // ---- find no, ndot, nddot ----
   satrec.no /= xpdotp; //   rad/min
-  // satrec.nddot= satrec.nddot * Math.pow(10.0, nexp);
-  // satrec.bstar= satrec.bstar * Math.pow(10.0, ibexp);
-
-  // ---- convert to sgp4 units ----
-  // satrec.ndot /= (xpdotp * 1440.0); // ? * minperday
-  // satrec.nddot /= (xpdotp * 1440.0 * 1440);
 
   // ---- find standard orbital elements ----
   satrec.inclo *= deg2rad;

--- a/src/sun.js
+++ b/src/sun.js
@@ -1,0 +1,145 @@
+import { deg2rad, twoPi } from './constants';
+
+////////////////////////////////////////////////////////////////////////////////////
+/* Line by Line MATLAB-to-Javascript conversion of "sun.mat" from Vallado package */
+////////////////////////////////////////////////////////////////////////////////////
+/* -----------------------------------------------------------------------------
+ *
+ *                              function sunPos
+ *
+ *  this function calculates the geocentric equatorial position vector
+ *      the sun given the julian date.  this is the low precision formula and
+ *      is valid for years from 1950 to 2050.  accuaracy of apparent coordinates
+ *      is 0.01  degrees.  notice many of the calculations are performed in
+ *      degrees, and are not changed until later.  this is due to the fact that
+ *      the almanac uses degrees exclusively in their formulations.
+ * 
+ *  author        : david vallado                  719-573-2600    1 mar 2001
+ * 
+ *  inputs          description                       range / units
+ *      jd          - julian date                       days from 4713 bc
+ * 
+ *  outputs       :
+ *      rsun        - ijk position vector of the sun    au
+ *      rtasc       - right ascension                   rad
+ *      decl        - declination                       rad
+ * 
+ *  coupling      :
+ *      -
+ * 
+ *  references    :
+ *      VALLADO, DAVID A. (2022) ‘Computer software in MATLAB’, in Fundamentals of astrodynamics and applications. 5th edn.
+ *      Computer software in MATLAB: http://celestrak.org/software/vallado-sw.php 
+ *  --------------------------------------------------------------------------- */
+
+export function sunPos(jd) {
+  
+    // -------------------------  implementation   -----------------
+    // -------------------  initialize values   --------------------
+    const tut1 = ( jd - 2451545.0  ) / 36525.0;
+  
+    const meanlong = (280.460  + 36000.77 * tut1) % 360.0; //deg
+  
+    const ttdb = tut1; // is this declaration required instead of replacing `ttdb` with `tut1`
+ 
+    if (meananomaly < 0.0 ) {
+        const meananomaly = twoPi + ((357.5277233  + 35999.05034 * ttdb) * deg2rad) % twoPi; //rad;
+    } else {
+        const meananomaly = ((357.5277233  + 35999.05034 * ttdb) * deg2rad) % twoPi; //rad;
+    }
+  
+    const eclplong_raw = ((meanlong + 1.914666471 * Math.sin(meananomaly) + 0.019994643 * Math.sin(2.0 * meananomaly)) % 360.0) * deg2rad; //rad
+  
+    const obliquity = (23.439291 - 0.0130042 * ttdb) * deg2rad; //rad
+  
+    // --------- find magnitude of sun vector, and it's components ------
+    const magr = 1.000140612  - 0.016708617 * Math.cos( meananomaly ) - 0.000139589 * Math.cos( 2.0 * meananomaly ); // in au's
+  
+    const rsun = [
+        magr*Math.cos(eclplong_raw), 
+        magr*Math.cos(obliquity)*Math.sin(eclplong_raw), 
+        magr*Math.sin(obliquity)*Math.sin(eclplong_raw)
+    ];
+  
+    const rtasc_raw = Math.atan( Math.cos(obliquity) * Math.tan(eclplong_raw) );
+  
+    // --- check that rtasc is in the same quadrant as eclplong_raw ----
+    if ( eclplong_raw < 0.0  ) {
+        const eclplong = eclplong_raw + twoPi;    // make sure it's in 0 to 2pi range
+    } else {
+        const eclplong = eclplong_raw;
+    }
+
+    if ( Math.abs( eclplong_raw - rtasc_raw ) > pi*0.5  ) {
+        const rtasc = rtasc_raw + 0.5 *pi*Math.round( (eclplong_raw - rtasc_raw)/(0.5 *pi));
+    } else {
+        const rtasc = rtasc_raw;
+    }
+    
+    const decl = Math.asin( Math.sin(obliquity) * Math.sin(eclplong_raw) );
+  
+    return {rsun, rtasc, decl}
+  }
+  
+  
+  /* Original MATLAB code for Sun position from Vallado package (sun.mat)  */
+  /*
+  function [rsun,rtasc,decl] = sun ( jd );
+  
+          twopi      =     2.0*pi;
+          deg2rad    =     pi/180.0;
+          show = 'n';
+  
+          % -------------------------  implementation   -----------------
+          % -------------------  initialize values   --------------------
+          tut1= ( jd - 2451545.0  )/ 36525.0;
+  
+          if show == 'y'
+              fprintf(1,'tut1 %14.9f \n',tut1);
+          end
+  
+          meanlong= 280.460  + 36000.77*tut1;
+          meanlong= rem( meanlong,360.0  );  %deg
+  
+          ttdb= tut1;
+          meananomaly= 357.5277233  + 35999.05034 *ttdb;
+          meananomaly= rem( meananomaly*deg2rad,twopi );  %rad
+          if ( meananomaly < 0.0  )
+              meananomaly= twopi + meananomaly;
+          end
+  
+          eclplong_raw= meanlong + 1.914666471 *sin(meananomaly) ...
+                      + 0.019994643 *sin(2.0 *meananomaly); %deg
+          eclplong_raw= rem( eclplong_raw,360.0  );  %deg
+  
+          obliquity= 23.439291  - 0.0130042 *ttdb;  %deg
+  
+          eclplong_raw = eclplong_raw *deg2rad;
+          obliquity= obliquity *deg2rad;
+  
+          % --------- find magnitude of sun vector, )   components ------
+          magr= 1.000140612  - 0.016708617 *cos( meananomaly ) ...
+                                - 0.000139589 *cos( 2.0 *meananomaly );    % in au's
+  
+          rsun(1)= magr*cos( eclplong_raw );
+          rsun(2)= magr*cos(obliquity)*sin(eclplong_raw);
+          rsun(3)= magr*sin(obliquity)*sin(eclplong_raw);
+  
+          if show == 'y'
+              fprintf(1,'meanlon %11.6f meanan %11.6f eclplon %11.6f obli %11.6f \n', ...
+                      meanlong,meananomaly/deg2rad,eclplong_raw/deg2rad,obliquity/deg2rad);
+              fprintf(1,'rs %11.9f %11.9f %11.9f \n',rsun);
+              fprintf(1,'magr %14.7f \n',magr);
+          end
+  
+          rtasc= atan( cos(obliquity)*tan(eclplong_raw) );
+  
+          % --- check that rtasc is in the same quadrant as eclplong_raw ----
+          if ( eclplong_raw < 0.0  )
+              eclplong_raw= eclplong_raw + twopi;    % make sure it's in 0 to 2pi range
+          end
+          if ( abs( eclplong_raw-rtasc ) > pi*0.5  )
+              rtasc= rtasc + 0.5 *pi*round( (eclplong_raw-rtasc)/(0.5 *pi));
+          end
+          decl = asin( sin(obliquity)*sin(eclplong_raw) );
+  */

--- a/test/ext.test.js
+++ b/test/ext.test.js
@@ -1,7 +1,7 @@
 import compareVectors from './compareVectors';
 
 import { jday, invjday } from '../src/ext';
-import twoline2satrec from '../src/io';
+import { twoline2satrec } from '../src/io';
 import { propagate, gstime } from '../src/propagation';
 
 describe('Julian date / time', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -17,7 +17,7 @@ import {
 } from '../src/constants';
 
 import { jday, invjday } from '../src/ext';
-import twoline2satrec from '../src/io';
+import { twoline2satrec, json2satrec } from '../src/io';
 import { propagate, sgp4, gstime } from '../src/propagation';
 
 import dopplerFactor from '../src/dopplerFactor';
@@ -74,6 +74,7 @@ function checkTransforms(transforms) {
 function checkExports(namespace) {
   it('constants', () => checkConstants(namespace.constants));
   it('twoline2satrec', () => expect(namespace.twoline2satrec).toEqual(twoline2satrec));
+  it('json2satrec', () => expect(namespace.json2satrec).toEqual(json2satrec));
   it('propagate', () => expect(namespace.propagate).toEqual(propagate));
   it('sgp4', () => expect(namespace.sgp4).toEqual(sgp4));
   it('gstime', () => expect(namespace.gstime).toEqual(gstime));

--- a/test/io-edge.json
+++ b/test/io-edge.json
@@ -1,0 +1,34 @@
+[
+  {
+    "tleLine1": "1 00001U 57001B   21005.53831292 -.00000083  00000-0 -11575-3 0  9996",
+    "tleLine2": "2 00001  34.2508 325.6936 1846988 181.8107 177.4919 00.00000000227203",
+    "description": "Mean motion is zero and that is not allowed.",
+    "results": [{
+      "error": 2
+    }]
+  },
+  {
+    "tleLine1": "1 00002U 57001B   21005.53831292 -.00000083  00000-0 -11575-3 0  9996",
+    "tleLine2": "2 00002  34.2508 325.6936 1846988 181.8107 177.4919 00.00000001227203",
+    "description": "Eccentricity is way too high because mean motion is nearly zero.",
+    "results": [{
+      "error": 3
+    }]
+  },
+  {
+    "tleLine1": "1 00004U 57001B   21005.53831292 -.00000083  00000-0 -11575-3 0  9996",
+    "tleLine2": "2 00004  34.2508 325.6936 9999999 181.8107 177.4919 10.84863720227203",
+    "description": "Eccentricity is way too high.",
+    "results": [{
+      "error": 4
+    }]
+  },
+  {
+    "tleLine1": "1 00006U 57001B   21005.53831292 -.00000083  00000-0 -11575-3 0  9996",
+    "tleLine2": "2 00005  34.2508 325.6936 1846988 181.8107 177.4919 25.84863720227203",
+    "description": "Satellite should be decayed already.",
+    "results": [{
+      "error": 6
+    }]
+  }
+]

--- a/test/io.json
+++ b/test/io.json
@@ -1,34 +1,65 @@
 [
-  {
-    "tleLine1": "1 00001U 57001B   21005.53831292 -.00000083  00000-0 -11575-3 0  9996",
-    "tleLine2": "2 00001  34.2508 325.6936 1846988 181.8107 177.4919 00.00000000227203",
-    "description": "Mean motion is zero and that is not allowed.",
-    "results": [{
-      "error": 2
-    }]
-  },
-  {
-    "tleLine1": "1 00002U 57001B   21005.53831292 -.00000083  00000-0 -11575-3 0  9996",
-    "tleLine2": "2 00002  34.2508 325.6936 1846988 181.8107 177.4919 00.00000001227203",
-    "description": "Eccentricity is way too high because mean motion is nearly zero.",
-    "results": [{
-      "error": 3
-    }]
-  },
-  {
-    "tleLine1": "1 00004U 57001B   21005.53831292 -.00000083  00000-0 -11575-3 0  9996",
-    "tleLine2": "2 00004  34.2508 325.6936 9999999 181.8107 177.4919 10.84863720227203",
-    "description": "Mean motion is zero and that is not allowed.",
-    "results": [{
-      "error": 4
-    }]
-  },
-  {
-    "tleLine1": "1 00006U 57001B   21005.53831292 -.00000083  00000-0 -11575-3 0  9996",
-    "tleLine2": "2 00005  34.2508 325.6936 1846988 181.8107 177.4919 25.84863720227203",
-    "description": "Satellite should be decayed already.",
-    "results": [{
-      "error": 6
-    }]
-  }
+    {
+        "tleLine1": "1 25544U 98067A   23231.51768399  .00014050  00000+0  25837-3 0  9996",
+        "tleLine2": "2 25544  51.6415  14.7889 0003559 325.3396 149.4637 15.49477580411611",
+        "OBJECT_NAME": "ISS (ZARYA)",
+        "OBJECT_ID": "1998-067A",
+        "EPOCH": "2023-08-19T12:25:27.896736",
+        "MEAN_MOTION": 15.4947758,
+        "ECCENTRICITY": 0.0003559,
+        "INCLINATION": 51.6415,
+        "RA_OF_ASC_NODE": 14.7889,
+        "ARG_OF_PERICENTER": 325.3396,
+        "MEAN_ANOMALY": 149.4637,
+        "EPHEMERIS_TYPE": 0,
+        "CLASSIFICATION_TYPE": "U",
+        "NORAD_CAT_ID": 25544,
+        "ELEMENT_SET_NO": 999,
+        "REV_AT_EPOCH": 41161,
+        "BSTAR": 0.00025837,
+        "MEAN_MOTION_DOT": 0.0001405,
+        "MEAN_MOTION_DDOT": 0
+    },
+    {
+        "tleLine1": "1 00005U 58002B   23230.80643200  .00000051  00000+0  62145-4 0  9990",
+        "tleLine2": "2 00005  34.2442 262.2777 1845847 161.4568 206.3458 10.85081473331065",
+        "OBJECT_NAME": "VANGUARD 1",
+        "OBJECT_ID": "1958-002B",
+        "EPOCH": "2023-08-18T19:21:15.724800",
+        "MEAN_MOTION": 10.85081473,
+        "ECCENTRICITY": 0.1845847,
+        "INCLINATION": 34.2442,
+        "RA_OF_ASC_NODE": 262.2777,
+        "ARG_OF_PERICENTER": 161.4568,
+        "MEAN_ANOMALY": 206.3458,
+        "EPHEMERIS_TYPE": 0,
+        "CLASSIFICATION_TYPE": "U",
+        "NORAD_CAT_ID": 5,
+        "ELEMENT_SET_NO": 999,
+        "REV_AT_EPOCH": 33106,
+        "BSTAR": 6.2145e-5,
+        "MEAN_MOTION_DOT": 5.1e-7,
+        "MEAN_MOTION_DDOT": 0
+    },
+    {
+        "tleLine1": "1 00012U 59001B   23230.77689364  .00000551  00000+0  33029-3 0  9998",
+        "tleLine2": "2 00012  32.8964 259.3305 1659877  44.2337 327.9558 11.45746962655202",
+        "OBJECT_NAME": "VANGUARD R\/B",
+        "OBJECT_ID": "1959-001B",
+        "EPOCH": "2023-08-18T18:38:43.610496",
+        "MEAN_MOTION": 11.45746962,
+        "ECCENTRICITY": 0.1659877,
+        "INCLINATION": 32.8964,
+        "RA_OF_ASC_NODE": 259.3305,
+        "ARG_OF_PERICENTER": 44.2337,
+        "MEAN_ANOMALY": 327.9558,
+        "EPHEMERIS_TYPE": 0,
+        "CLASSIFICATION_TYPE": "U",
+        "NORAD_CAT_ID": 12,
+        "ELEMENT_SET_NO": 999,
+        "REV_AT_EPOCH": 65520,
+        "BSTAR": 0.00033029,
+        "MEAN_MOTION_DOT": 5.51e-6,
+        "MEAN_MOTION_DDOT": 0
+    }
 ]

--- a/test/io.test.js
+++ b/test/io.test.js
@@ -1,14 +1,38 @@
-import twoline2satrec from '../src/io';
-import badTleData from './io.json';
+import { twoline2satrec, json2satrec } from '../src/io';
+import badTleData from './io-edge.json';
+import goodData from './io.json';
 
 describe('Twoline', () => {
-  it('twoline to satellite record', () => {
-    badTleData.forEach((tleDataItem) => {
-      const satrec = twoline2satrec(tleDataItem.tleLine1, tleDataItem.tleLine2);
-      tleDataItem.results.forEach((expected) => {
-        // Fetching satellite record from incorrectly formatted TLE lines
-        expect(satrec.error).toEqual(expected.error);
-      });
+    it('should convert twoline to satellite record', () => {
+        badTleData.forEach((tleDataItem) => {
+            const satrec = twoline2satrec(tleDataItem.tleLine1, tleDataItem.tleLine2);
+            tleDataItem.results.forEach((expected) => {
+                // Fetching satellite record from incorrectly formatted TLE lines
+                expect(satrec.error).toEqual(expected.error);
+            });
+        });
     });
-  });
 });
+
+describe('OMM Format Conversion', () => {
+    goodData.forEach(jsonObj => {
+        const satrec = json2satrec(jsonObj);
+        const origSatrec = twoline2satrec(jsonObj.tleLine1, jsonObj.tleLine2);
+        for (const prop in origSatrec) {
+            it(`should have a valid ${prop} property`, () => {
+                switch (prop) {
+                    case 'epochdays':
+                    case 'jdsatepoch':
+                        expect(satrec[prop]).toBeCloseTo(origSatrec[prop], 7);
+                        break;
+                    case 'gsto':
+                        expect(satrec[prop]).toBeCloseTo(origSatrec[prop], 6);
+                        break;
+                    default:
+                        expect(satrec[prop]).toEqual(origSatrec[prop]);
+                        break;
+                }
+            });
+        }
+    });
+})

--- a/test/propagation/sgp4Catalog.test.js
+++ b/test/propagation/sgp4Catalog.test.js
@@ -2,7 +2,7 @@ import path from 'path';
 import fs from 'fs';
 
 import sgp4 from '../../src/propagation/sgp4';
-import twoline2satrec from '../../src/io';
+import { twoline2satrec } from '../../src/io';
 
 const satellitesPerTestSuite = 500;
 


### PR DESCRIPTION
Added function `json2satrec` in `io.js` to initialise `sgp4init` object and build `satrec` object from OMM data in JSON format. Ref: [A New Way to Obtain GP Data (aka TLEs)](https://celestrak.org/NORAD/documentation/gp-data-formats.php).

This is the new way of distributing TLEs and would become the new standard soon. It is better to port our functions slowly for compatibility.

#105 