### PR TITLE
Fix Error in calculating the Doppler Factor

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "bugs": {
     "url": "https://github.com/shashwatak/satellite-js/issues"
   },
-  "dependencies": {},
   "devDependencies": {
     "@babel/cli": "^7.20.7",
     "@babel/core": "^7.20.12",
@@ -60,7 +59,7 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.26.0",
     "glob": "^8.0.3",
-    "jest": "^29.3.1",
+    "jest": "^29.7.0",
     "prepend-file": "^2.0.1",
     "raise-version": "^0.5.0",
     "rimraf": "^3.0.2",

--- a/src/dopplerFactor.js
+++ b/src/dopplerFactor.js
@@ -1,5 +1,5 @@
 export default function dopplerFactor(location, position, velocity) {
-  const mfactor = 7.292115E-5;
+  const earthRotation = 7.292115E-5;
   const c = 299792.458; // Speed of light in km/s
 
   const range = {
@@ -10,16 +10,16 @@ export default function dopplerFactor(location, position, velocity) {
   range.w = Math.sqrt(range.x ** 2 + range.y ** 2 + range.z ** 2);
 
   const rangeVel = {
-    x: velocity.x + mfactor * location.y,
-    y: velocity.y - mfactor * location.x,
+    x: velocity.x + earthRotation * location.y,
+    y: velocity.y - earthRotation * location.x,
     z: velocity.z,
   };
 
-  function sign(value) {
-    return value >= 0 ? 1 : -1;
-  }
-
   const rangeRate = (range.x * rangeVel.x + range.y * rangeVel.y + range.z * rangeVel.z) / range.w;
 
-  return (1 + (rangeRate / c) * sign(rangeRate));
+  // Negative range rate means the satellite is moving towards the observer and
+  // its frequency is shifted higher because 1 minus a negative range rate is
+  // positive. If the range rate is positive, the satellite is moving away from
+  // the observer and its frequency is shifted lower.
+  return 1 - rangeRate / c;
 }

--- a/test/dopplerFactor.test.js
+++ b/test/dopplerFactor.test.js
@@ -48,6 +48,7 @@ describe('Doppler factor', () => {
     expect(dopFactor).toBeCloseTo(1, numDigits);
   });
 
+  // Object moving away from observer
   it('special case', () => {
     const observerEcf = {
       x: earthRadius,
@@ -65,7 +66,7 @@ describe('Doppler factor', () => {
       z: 0,
     };
     const dopFactor = dopplerFactor(observerEcf, positionEcf, velocityEcf);
-    expect(dopFactor).toBeCloseTo(1.0000107847789212, numDigits);
+    expect(dopFactor).toBeCloseTo(0.9999892152210788, numDigits);
   });
 
   it('calculated from a negative range rate', () => {


### PR DESCRIPTION
PR to fix #126.

I updated Jest because the previous version was throwing errors when looking at the sgp4 snapshots.