### PR TITLE
Add mean orbit elements at the propagation time to propagation results

### DIFF
--- a/src/propagation/sgp4.js
+++ b/src/propagation/sgp4.js
@@ -255,6 +255,16 @@ export default function sgp4(satrec, tsince) {
   xlm %= twoPi;
   mm = (xlm - argpm - nodem) % twoPi;
 
+  const meanElements = {
+    am: am,
+    em: em,
+    im: inclm,
+    Om: nodem,
+    om: argpm,
+    mm: mm,
+    nm: nm,
+  };
+
   // ----------------- compute extra mean quantities -------------
   const sinim = Math.sin(inclm);
   const cosim = Math.cos(inclm);
@@ -390,6 +400,7 @@ export default function sgp4(satrec, tsince) {
     return {
       position: false,
       velocity: false,
+      meanElements,
     };
   }
 
@@ -430,6 +441,7 @@ export default function sgp4(satrec, tsince) {
   return {
     position: r,
     velocity: v,
+    meanElements,
   };
 
   /* eslint-enable no-param-reassign */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -97,13 +97,57 @@ declare module 'satellite.js' {
   export type KilometerPerSecond = number;
 
   /**
+   * A set of "singly averaged mean elements" that describe shape of the
+   * satellite’s orbit at the moment of propagation. They are averaged
+   * with respect to the mean anomaly and include the effects of secular
+   * gravity, atmospheric drag, and - in Deep Space mode - of those
+   * pertubations from the Sun and Moon that SGP4 averages over an entire
+   * revolution of each of those bodies. They omit both the shorter-term
+   * and longer-term periodic pertubations from the Sun and Moon that
+   * SGP4 applies right before computing each position.
+   */
+  export type MeanElements = {
+    /**
+     * Average semi-major axis (earth radii).
+     */
+    am: number;
+    /**
+     * Average eccentricity.
+     */
+    em: number;
+    /**
+     * Average inclination (radians).
+     */
+    im: Radians;
+    /**
+     * Average right ascension of ascending node (radians).
+     */
+    Om: Radians;
+    /**
+     * Average argument of perigee (radians).
+     */
+    om: Radians;
+    /**
+     * Average mean anomaly (radians).
+     */
+    mm: Radians;
+    /**
+     * Average mean motion (radians/minute).
+     */
+    nm: number;
+  }
+
+  /**
    * The position_velocity result is a key-value pair of ECI coordinates.
    * These are the base results from which all other coordinates are derived.
    * If there is an error the position and velocity will be false.
+   * The meanElements are the averaged elements of the orbit at the
+   * moment of propagation.
    */
   export interface PositionAndVelocity {
     position: EciVec3<Kilometer>|boolean;
     velocity: EciVec3<KilometerPerSecond>|boolean;
+    meanElements: MeanElements;
   }
 
   /**


### PR DESCRIPTION
This adds something that either was omitted while porting the original Python implementation, or didn't exist at the time of the port: calculation of orbital elements for the propagation time. The original implementation, however, sets them to the original SatRec (see screenshot)
![image](https://github.com/user-attachments/assets/93df6be4-942a-488f-b209-57ba3d424de8)
I decided it would be better to return them together with the rest of propagation result.

They are computed always under the hood anyway, so the only overhead might be just for the object instantiation.

I decided to reuse existing Radians type for values that use them, but there are a few other units such as Earth radius and radians/minute. I can add types for those as well if you wish, I used `number` for now.

This is the relevant section of the docs from the Python lib: https://pypi.org/project/sgp4/#:~:text=Mean%20Elements%20From%20Most%20Recent%20Propagation