### PR TITLE
Introduce `SatRecError`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,5 +21,5 @@ export {
 } from './transforms';
 
 export { sunPos } from './sun';
-export type { SatRec } from './propagation/SatRec.js';
+export { type SatRec, SatRecError } from './propagation/SatRec.js';
 export * from './common-types.js';

--- a/src/indexUmd.ts
+++ b/src/indexUmd.ts
@@ -3,6 +3,7 @@ import * as constants from './constants';
 import { jday, invjday } from './ext';
 import { twoline2satrec, json2satrec} from './io';
 import { propagate, sgp4, gstime } from './propagation';
+import { SatRecError } from './propagation/SatRec.js';
 import * as types from './common-types.js';
 
 import dopplerFactor from './dopplerFactor';
@@ -56,4 +57,6 @@ export default {
 
   // Types
   ...types,
+
+  SatRecError,
 };

--- a/src/propagation/SatRec.ts
+++ b/src/propagation/SatRec.ts
@@ -1,11 +1,66 @@
+export enum SatRecError {
+  /**
+   * No error, propagation for the last supplied date is successful
+   */
+  None = 0,
+  /**
+   * Mean eccentricity is out of range 0 ≤ e < 1
+   */
+  MeanEccentricityOutOfRange = 1,
+  /**
+   * Mean motion has fallen below zero.
+   */
+  MeanMotionBelowZero = 2,
+  /**
+   * Perturbed eccentricity is out of range 0 ≤ e < 1
+   */
+  PerturbedEccentricityOutOfRange = 3,
+  /**
+   * Length of the orbit’s semi-latus rectum has fallen below zero.
+   */
+  SemiLatusRectumBelowZero = 4,
+  // 5 is not used
+  /**
+   * Orbit has decayed: the computed position is underground.
+   */
+  Decayed = 6,
+}
+
+/**
+ * A structure that contains all the information needed to propagate a satellite's orbit using the SGP4 model.
+ * 
+ * Mostly you can consider it opaque as you only need to pass it to `propagate` function.
+ * All properties should be considered read-only as they're used and set by SGP4 model internally.
+ * 
+ * This interface is a direct translation of C++ struct `elsetrec` from the source code by David Vallado;
+ * all changes to the original struct are documented.
+ */
 export interface SatRec {
+  /**
+   * Stringified satellite number, usually from NORAD catalog
+   */
   satnum: string;
+  /**
+   * Full four-digit year of this element set's epoch moment
+   */
   epochyr: number;
   epochtynumrev: number;
-  error: number;
+  /**
+   * Error code produced by the most recent SGP4 propagation you performed with this element set.
+   */
+  error: SatRecError;
+  /**
+   * A single character that directs SGP4 to either operate in its modern 'i' improved mode or
+   * in its legacy 'a' AFSPC mode.
+   */
   operationmode: 'a' | 'i';
   init: 'y' | 'n';
-  method: string;
+  /**
+   * A single character, chosen automatically when the orbital elements were loaded, that
+   * indicates whether SGP4 has chosen to use its built-in 'n' Near Earth or 'd' Deep Space
+   * mode for this satellite.
+   */
+  method: 'n' | 'd';
 
   /* Near Earth */
   isimp: number;
@@ -22,6 +77,10 @@ export interface SatRec {
   argpdot: number;
   omgcof: number;
   sinmao: number;
+  /**
+   * The time you gave when you most recently asked SGP4 to compute this satellite’s position,
+   * measured in minutes before (negative) or after (positive) the satellite’s epoch.
+   */
   t: number;
   t2cof: number;
   t3cof: number;
@@ -97,14 +156,15 @@ export interface SatRec {
   altp: number;
   alta: number;
   /**
-   * Fractional days into the year of the epoch moment.
+   * Fractional days into the year of the epoch moment in UTC.
    */
   epochdays: number;
   /**
    * Julian date of the epoch (computed from epochyr and epochdays).
    */
   jdsatepoch: number;
-  jdsatepochF: number;
+  // fractional part is not needed for JS as it's retained in the `jdsatepoch` field
+  // jdsatepochF: number;
   /**
    * Second time derivative of the mean motion (ignored by SGP4).
    */
@@ -117,7 +177,8 @@ export interface SatRec {
    * Ballistic drag coefficient B* in inverse earth radii.
    */
   bstar: number;
-  rcse: number;
+  // not used by the library
+  // rcse: number;
   /**
    * Inclination in radians.
    */
@@ -144,7 +205,8 @@ export interface SatRec {
   no: number;
   
   // sgp4fix add unkozai'd variable
-  no_unkozai: number;
+  // not used by the library
+  // no_unkozai: number;
   
   // sgp4fix add singly averaged variables
   // this is instead returned in propagation results

--- a/src/propagation/sgp4.ts
+++ b/src/propagation/sgp4.ts
@@ -12,7 +12,7 @@ import {
 
 import dpper from './dpper';
 import dspace from './dspace';
-import { SatRec } from './SatRec.js';
+import { SatRec, SatRecError } from './SatRec.js';
 
 /*----------------------------------------------------------------------------
  *
@@ -138,7 +138,7 @@ export default function sgp4(satrec: SatRec, tsince: number): PositionAndVelocit
 
   // --------------------- clear sgp4 error flag -----------------
   satrec.t = tsince;
-  satrec.error = 0;
+  satrec.error = SatRecError.None;
 
   //  ------- update for secular gravity and atmospheric drag -----
   const xmdf = satrec.mo + (satrec.mdot * satrec.t);
@@ -225,7 +225,7 @@ export default function sgp4(satrec: SatRec, tsince: number): PositionAndVelocit
 
   if (nm <= 0.0) {
     // printf("// error nm %f\n", nm);
-    satrec.error = 2;
+    satrec.error = SatRecError.MeanMotionBelowZero;
     // sgp4fix add return
     return null;
   }
@@ -238,7 +238,7 @@ export default function sgp4(satrec: SatRec, tsince: number): PositionAndVelocit
   // sgp4fix am is fixed from the previous nm check
   if (em >= 1.0 || em < -0.001) { // || (am < 0.95)
     // printf("// error em %f\n", em);
-    satrec.error = 1;
+    satrec.error = SatRecError.MeanEccentricityOutOfRange;
     // sgp4fix to return if there is an error in eccentricity
     return null;
   }
@@ -307,7 +307,7 @@ export default function sgp4(satrec: SatRec, tsince: number): PositionAndVelocit
     }
     if (ep < 0.0 || ep > 1.0) {
       //  printf("// error ep %f\n", ep);
-      satrec.error = 3;
+      satrec.error = SatRecError.PerturbedEccentricityOutOfRange;
       //  sgp4fix add return
       return null;
     }
@@ -363,7 +363,7 @@ export default function sgp4(satrec: SatRec, tsince: number): PositionAndVelocit
   const pl = am * (1.0 - el2);
   if (pl < 0.0) {
     //  printf("// error pl %f\n", pl);
-    satrec.error = 4;
+    satrec.error = SatRecError.SemiLatusRectumBelowZero;
     //  sgp4fix add return
     return null;
   }
@@ -396,7 +396,7 @@ export default function sgp4(satrec: SatRec, tsince: number): PositionAndVelocit
   // sgp4fix for decaying satellites
   if (mrt < 1.0) {
     // printf("// decay condition %11.6f \n",mrt);
-    satrec.error = 6;
+    satrec.error = SatRecError.Decayed;
     return null;
   }
 


### PR DESCRIPTION
Adds `SatRecError` enum instead of hardcoded undocumented numeric values. Also documents SatRec better.