### PR TITLE
Restructure readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![NPM version](https://img.shields.io/npm/v/satellite.js.svg)](https://www.npmjs.com/package/satellite.js)
 [![Downloads/month](https://img.shields.io/npm/dm/satellite.js.svg)](https://www.npmjs.com/package/satellite.js)
-[![Build Status](https://img.shields.io/travis/shashwatak/satellite-js/develop.svg)](https://travis-ci.org/shashwatak/satellite-js)
-[![Gitter chat](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/satellite-js/Lobby)
 [![License](https://img.shields.io/github/license/mashape/apistatus.svg)](LICENSE.md)
 
 ## Introduction

--- a/README.md
+++ b/README.md
@@ -13,11 +13,7 @@ possible in the web. Provides the functions necessary for SGP4/SDP4 calculations
 functions for coordinate transforms.
 
 The internals of this library are nearly identical to
-[Brandon Rhode's sgp4 python library](https://pypi.python.org/pypi/sgp4/). However, it is encapsulated in a
-standard JS library (self executing function), and exposes only the functionality needed to track satellites and
-propagate paths. The only changes I made to Brandon Rhode's code was to change the positional parameters of
-functions to key:value objects. This reduces the complexity of functions that require 50+ parameters,
-and doesn't require the parameters to be placed in the exact order.
+[Brandon Rhode's sgp4 python library](https://pypi.python.org/pypi/sgp4/).
 
 Special thanks to all contributors for improving usability and bug fixes :)
 
@@ -36,47 +32,13 @@ Special thanks to all contributors for improving usability and bug fixes :)
 - [owntheweb](https://github.com/owntheweb)
 - [Zigone](https://github.com/Zigone)
 
-If you want to contribute to the project please read the [Contributing](#contributing) section first.
-
 Sites using the library can be found [here](https://github.com/shashwatak/satellite-js/wiki/Sites-using-satellite.js).
 
-**Start Here:**
-
-- [TS Kelso's Columns for Satellite Times](http://celestrak.com/columns/), Orbital Propagation Parts I and II a must!
-- [Wikipedia: Simplified Perturbations Model](http://en.wikipedia.org/wiki/Simplified_perturbations_models)
-- [SpaceTrack Report #3, by Hoots and Roehrich](http://celestrak.com/NORAD/documentation/spacetrk.pdf).
-
-The javascript in this library is heavily based (straight copied) from:
-
-- The python [sgp4 1.1 by Brandon Rhodes](https://pypi.python.org/pypi/sgp4/)
-- The C++ code by [David Vallado, et al](http://www.celestrak.com/publications/AIAA/2006-6753/)
-
-I've included the original PKG-INFO file from the python library.
-
-The coordinate transforms are based off T.S. Kelso's columns:
-
-- [Part I](http://celestrak.com/columns/v02n01/)
-- [Part II](http://celestrak.com/columns/v02n02/)
-- [Part III](http://celestrak.com/columns/v02n03/)
-
-And the coursework for UC Boulder's ASEN students
-- [Coodinate Transforms @ UC Boulder](http://ccar.colorado.edu/ASEN5070/handouts/coordsys.doc)
-
-I would recommend anybody interested in satellite tracking or orbital propagation to read
-[all of TS Kelso's columns](http://celestrak.com/columns/). Without his work, this project would not be possible.
-
-Get a free [Space Track account](https://www.space-track.org/auth/login) and download your own up to date TLEs
-for use with this library.
-
 ## Installation
-
-Install the library with [NPM](https://www.npmjs.com/):
 
 ```bash
 npm install satellite.js
 ```
-
-Install the library with [Yarn](https://yarnpkg.com/):
 
 ```bash
 yarn add satellite.js
@@ -84,20 +46,20 @@ yarn add satellite.js
 
 ## Usage
 
+### ES Modules
+
+```js
+import { sgp4 } from 'satellite.js';
+...
+const positionAndVelocity = sgp4(satrec, time);
+```
+
 ### Common.js ([Node.js](https://nodejs.org))
 
 ```js
 const satellite = require('satellite.js');
 ...
 const positionAndVelocity = satellite.sgp4(satrec, time);
-```
-
-### ES ([Babel.js](https://babeljs.io/))
-
-```js
-import { sgp4 } from 'satellite.js';
-...
-const positionAndVelocity = sgp4(satrec, time);
 ```
 
 ### AMD ([Require.js](http://requirejs.org/))
@@ -108,8 +70,6 @@ define(['path/to/dist/satellite'], function(satellite) {
     var positionAndVelocity = satellite.sgp4(satrec, time);
 });
 ```
-
-[Here is a repo](https://github.com/solarpatrol/satellite-requirejs) showing basic library usage with Require.js.
 
 ### Script tag
 
@@ -125,17 +85,17 @@ Include `dist/satellite.min.js` as a script in your html:
 const positionAndVelocity = satellite.sgp4(satrec, time);
 ```
 
-## Sample Usage
+## Sample Usage: calculate Look Angles, Geodetic Position etc
     
 ```js
 // Sample TLE
 const tleLine1 = '1 25544U 98067A   19156.50900463  .00003075  00000-0  59442-4 0  9992',
-      tleLine2 = '2 25544  51.6433  59.2583 0008217  16.4489 347.6017 15.51174618173442';    
+      tleLine2 = '2 25544  51.6433  59.2583 0008217  16.4489 347.6017 15.51174618173442';
 
 // Initialize a satellite record
 const satrec = satellite.twoline2satrec(tleLine1, tleLine2);
 
-// Or sample OMM
+// Or sample OMM - preferred for new applications
 const omm = {
   "OBJECT_NAME": "HELIOS 2A",
   "OBJECT_ID": "2004-049A",
@@ -154,9 +114,9 @@ const omm = {
   "BSTAR": 0.00048021,
   "MEAN_MOTION_DOT": 0.00005995,
   "MEAN_MOTION_DDOT": 0
-}
+};
 
-const satrecFromOmm = satellite.json2satrec(omm)
+const satrecFromOmm = satellite.json2satrec(omm);
 
 //  Propagate satellite using time since epoch (in minutes).
 const positionAndVelocity = satellite.sgp4(satrec, timeSinceTleEpochMinutes);
@@ -218,116 +178,34 @@ const longitude = positionGd.longitude,
 const longitudeDeg = satellite.degreesLong(longitude),
       latitudeDeg  = satellite.degreesLat(latitude);
 ```
-    
-## Contributing
 
-This repo follows [Gitflow Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow).
-Before starting a work on new [pull request](https://github.com/shashwatak/satellite-js/compare), please, checkout your
-feature or bugfix branch from `develop` branch:
+## Resources
 
-```bash
-git checkout develop
-git fetch origin
-git merge origin/develop
-git checkout -b my-feature
-```
+- [TS Kelso's Columns for Satellite Times](http://celestrak.com/columns/), Orbital Propagation Parts I and II a must!
+- [Wikipedia: Simplified Perturbations Model](http://en.wikipedia.org/wiki/Simplified_perturbations_models)
+- [SpaceTrack Report #3, by Hoots and Roehrich](http://celestrak.com/NORAD/documentation/spacetrk.pdf).
 
-Make sure that your changes don't break the existing code by running
+The TypeScript in this library is heavily based (propagation procedures straight copied) from:
 
-```bash
-npm test
-```
+- The python [sgp4 1.1 by Brandon Rhodes](https://pypi.python.org/pypi/sgp4/)
+- The C++ code by [David Vallado, et al](http://www.celestrak.com/publications/AIAA/2006-6753/)
 
-and that your code follows [Airbnb](https://www.npmjs.com/package/eslint-config-airbnb-base) style
+The original PKG-INFO file from the python library is included.
 
-```bash
-npm run lint
-npm run lint:test
-```
+The coordinate transforms are based off T.S. Kelso's columns:
 
-Implementing new functions or features, please, if possible, provide tests to cover them and mention your works in
-[Changelog](CHANGELOG.md). Please don't change version number in `package.json` and don't add it to `CHANGELOG.md`.
-All these things should be done later with [raise-version](https://github.com/ezze/node-raise-version) when
-merging to `master`:
+- [Part I](http://celestrak.com/columns/v02n01/)
+- [Part II](http://celestrak.com/columns/v02n02/)
+- [Part III](http://celestrak.com/columns/v02n03/)
 
-```bash
-npm run raise major
-```
+And the coursework for UC Boulder's ASEN students
+- [Coodinate Transforms @ UC Boulder](http://ccar.colorado.edu/ASEN5070/handouts/coordsys.doc)
 
-or
+I would recommend anybody interested in satellite tracking or orbital propagation to read
+[all of TS Kelso's columns](http://celestrak.com/columns/). Without his work, this project would not be possible.
 
-```bash
-npm run raise minor
-```
-
-or
-
-```bash
-npm run raise patch
-```
-
-In order to get test code coverage run the following:
-
-```bash
-npm run test:coverage
-```
-
-## Building
-
-The source code is written in [TypeScript](https://www.typescriptlang.org/) and uses a strict tsconfig.
-
-In order to build the library follow these steps:
-
-- install [Node.js](https://nodejs.org/) and [Node Package Manager](https://www.npmjs.com/);
-
-- install all required packages with NPM by running the following command from repository's root directory:
-
-    ```bash
-    npm install
-    ```
-
-- run the following NPM script to build everything:
-
-    ```bash
-    npm run build
-    ```
-
-- run the following NPM script to run test specs `test/*.spec.js` files with [Mocha](https://mochajs.org/):
-
-    ```bash
-    npm test
-    ```
-
-These is a full list of all available NPM scripts:
-
-- `build`           builds everything;
-- `transpile`       transpiles ES source files located in `src` directory to Common.js compatible modules and saves
-                    the resulting files in `lib` directory;
-- `dist`            builds ES and UMD modules in `dist` directory;
-- `dist:es`         builds ES module in `dist` directory;
-- `dist:umd`        builds [UMD](https://github.com/umdjs/umd) module in `dist` directory (both non-compressed and
-                    compressed versions);
-- `dist:umd:dev`    builds non-compressed version of UMD module in `dist` directory;
-- `dist:umd:prod`   builds compressed version of UMD module in `dist` directory; 
-- `watch:es`        watches for changes in `src` directory and automatically rebuilds ES module;
-- `copy`            copies built library from `dist` to [SGP4 verification](#benchmarking) application's directory;
-- `lint`            lints sources code located in `src` directory with [ESLint](http://eslint.org/) with
-                    [Airbnb shared configuration]((https://www.npmjs.com/package/eslint-config-airbnb));
-- `lint:test`       lints tests located in `test` directory with ESLint;
-- `test`            runs tests;
-- `test:coverage`   runs tests with [Istanbul](https://github.com/gotwarlost/istanbul) coverage summary;
-
-## ES5 and satellite.min.js
-
-Some people are confused that they can't just download a single satellite.js or satellite.min.js file. That is because satellite.js is not written in plain old JavaScript (ES5) anymore but ported to latter JavaScript versions ES6+.
-
-Only the "src" directory is included in the Git repository, "dist" and "lib" directories are ignored. It's done intentionally to retain the size of the repository as small as possible. A full detailed explanation of why is located [here](https://github.com/shashwatak/satellite-js/issues/80#issuecomment-749225324).
-
-You should install satellite.js with your package manager (npm or yarn) and then find satellite.js and satellite.min.js in node_modules/satellite.js/dist directory.
-
-## TODO
-
-Optional functions that utilize Worker Threads
+Get a free [Space Track account](https://www.space-track.org/auth/login) and download your own up to date TLEs or OMM
+for use with this library.
 
 ## Exposed Objects
 
@@ -355,16 +233,42 @@ suggest that anybody try to simplify it unless they have absolute understanding 
 
 ### Initialization
 
+NOTE! You are responsible for providing OMM or TLE.
+[Get your free Space Track account here.](https://www.space-track.org/auth/login)
+If you use Space Track, there should be no problem.
+
+#### From OMM (preferred for new applications)
+
+```js
+const satrec = satellite.json2satrec(ommObject);
+```
+
+returns satrec object, created from JSON object that follows
+[OMM format](https://www.nasa.gov/wp-content/uploads/2017/12/orbit_data_messages.pdf).
+**OMM is a preferred default method for new applications**, since TLE format is constrained
+to 5 digits in NORAD section and the number of catalogued objects quickly approches 100 000.
+
+To obtain OMM as JSON from Celestrak, select "JSON" option at the top of "Current GP
+Element Sets" page or follow
+[this link](https://celestrak.org/NORAD/elements/index.php?FORMAT=json) where it will
+be already selected.
+
+Space-Track doesn't expose the JSON format in their UI, so to get JSON encoded OMM,
+on "Recent ELSETs" page, from "Current Catalog Files", copy a URL for the needed category
+and change the ending part of the URL from `/format/xml` to be `/format/json`.
+
+#### From TLE
+
 ```js
 const satrec = satellite.twoline2satrec(longstr1, longstr2);
 ```
 
-returns satrec object, created from the TLEs passed in. The satrec object is vastly complicated, but you don't have
-to do anything with it, except pass it around.
+returns satrec object, created from the TLEs passed in. longstr1 and longstr2 are the two lines of the TLE,
+properly formatted by NASA and NORAD standards.
 
-NOTE! You are responsible for providing TLEs. [Get your free Space Track account here.](https://www.space-track.org/auth/login)
-longstr1 and longstr2 are the two lines of the TLE, properly formatted by NASA and NORAD standards. if you use
-Space Track, there should be no problem.
+___
+
+The satrec object is vastly complicated, but you don't have to do anything with it, except pass it around.
 
 ### Propagation
 
@@ -500,6 +404,110 @@ const sunPosition = satellite.sunPos(jday)
 }
 ```
 
+## Contributing
+
+This repo follows [Gitflow Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow).
+Before starting a work on new [pull request](https://github.com/shashwatak/satellite-js/compare), please, checkout your
+feature or bugfix branch from `develop` branch:
+
+```bash
+git checkout develop
+git fetch origin
+git merge origin/develop
+git checkout -b my-feature
+```
+
+Make sure that your changes don't break the existing code by running
+
+```bash
+npm test
+```
+
+and that your code follows [Airbnb](https://www.npmjs.com/package/eslint-config-airbnb-base) style
+
+```bash
+npm run lint
+npm run lint:test
+```
+
+Implementing new functions or features, please, if possible, provide tests to cover them and mention your works in
+[Changelog](CHANGELOG.md). Please don't change version number in `package.json` and don't add it to `CHANGELOG.md`.
+All these things should be done later with [raise-version](https://github.com/ezze/node-raise-version) when
+merging to `master`:
+
+```bash
+npm run raise major
+```
+
+or
+
+```bash
+npm run raise minor
+```
+
+or
+
+```bash
+npm run raise patch
+```
+
+In order to get test code coverage run the following:
+
+```bash
+npm run test:coverage
+```
+
+## Building
+
+The source code is written in [TypeScript](https://www.typescriptlang.org/) and uses a strict tsconfig.
+
+In order to build the library follow these steps:
+
+- install [Node.js](https://nodejs.org/) and [Node Package Manager](https://www.npmjs.com/);
+
+- install all required packages with NPM by running the following command from repository's root directory:
+
+    ```bash
+    npm install
+    ```
+
+- run the following NPM script to build everything:
+
+    ```bash
+    npm run build
+    ```
+
+- run the following NPM script to run test specs `test/*.spec.js` files with [Mocha](https://mochajs.org/):
+
+    ```bash
+    npm test
+    ```
+
+These is a full list of all available NPM scripts:
+
+- `build`           builds everything;
+- `transpile`       transpiles ES source files located in `src` directory to Common.js compatible modules and saves
+                    the resulting files in `lib` directory;
+- `dist`            builds ES and UMD modules in `dist` directory;
+- `dist:es`         builds ES module in `dist` directory;
+- `dist:umd`        builds [UMD](https://github.com/umdjs/umd) module in `dist` directory (both non-compressed and
+                    compressed versions);
+- `dist:umd:dev`    builds non-compressed version of UMD module in `dist` directory;
+- `dist:umd:prod`   builds compressed version of UMD module in `dist` directory; 
+- `watch:es`        watches for changes in `src` directory and automatically rebuilds ES module;
+- `copy`            copies built library from `dist` to [SGP4 verification](#benchmarking) application's directory;
+- `lint`            lints sources code located in `src` directory with [ESLint](http://eslint.org/) with
+                    [Airbnb shared configuration]((https://www.npmjs.com/package/eslint-config-airbnb));
+- `lint:test`       lints tests located in `test` directory with ESLint;
+- `test`            runs tests;
+- `test:coverage`   runs tests with [Istanbul](https://github.com/gotwarlost/istanbul) coverage summary;
+
+## ES5 and satellite.min.js
+
+Only the "src" directory is included in the Git repository, "dist" and "lib" directories are ignored. It's done intentionally to retain the size of the repository as small as possible. A full detailed explanation of why is located [here](https://github.com/shashwatak/satellite-js/issues/80#issuecomment-749225324).
+
+You should install satellite.js with your package manager (npm or yarn) and then find satellite.js and satellite.min.js in node_modules/satellite.js/dist directory.
+
 ## Note about Code Conventions
 
 Like Brandon Rhodes before me, I chose to maintain as little difference between this implementation and the prior
@@ -543,8 +551,7 @@ All files marked with the License header at the top are Licensed. Any files unma
 unlicensed, and are kept only as a resource for [Shashwat Kandadai and other developers] for testing.
 
 I chose the [MIT License](LICENSE.md) because this library is a derivative work off
-[Brandon Rhodes sgp4](https://pypi.python.org/pypi/sgp4/), and that is licensed with MIT. It just seemed simpler
-this way, sub-licensing freedoms notwithstanding.
+[Brandon Rhodes sgp4](https://pypi.python.org/pypi/sgp4/), and that is licensed with MIT.
 
 I worked in the Dining Hall at UCSC for a month, which means I signed a form that gives UCSC partial ownership of
 anything I make while under their aegis, so I included them as owners of the copyright.

--- a/README.md
+++ b/README.md
@@ -209,10 +209,10 @@ for use with this library.
 
 ## Exposed Objects
 
-### satrec
+### SatRec
 
-The `satrec` object comes from the original code by Rhodes as well as Vallado. It is immense and complex, but the
-most important values it contains are the Keplerian Elements and the other values pulled from the TLEs. I do not
+The `SatRec` object comes from the original code by Rhodes as well as Vallado. It is immense and complex, but the
+most important values it contains are the Keplerian Elements and the other values pulled from the TLE/OMM. I do not
 suggest that anybody try to simplify it unless they have absolute understanding of Orbital Mechanics.
 
 - `satnum`      Unique satellite number given in the TLE file.
@@ -228,6 +228,17 @@ suggest that anybody try to simplify it unless they have absolute understanding 
 - `argpo`       Argument of perigee in radians.
 - `mo`          Mean anomaly in radians.
 - `no`          Mean motion in radians per minute.
+- `error`       The error code that is set by SGP4 model in case when propagation fails.
+
+### SatRecError
+
+The enum that lists all possible error codes in `SatRec.error property:
+- `None` - No error, propagation for the last supplied date is successful
+- `MeanEccentricityOutOfRange` - Mean eccentricity is out of range 0 ≤ e < 1
+- `MeanMotionBelowZero` - Mean motion has fallen below zero
+- `PerturbedEccentricityOutOfRange` - Perturbed eccentricity is out of range 0 ≤ e < 1
+- `SemiLatusRectumBelowZero` - Length of the orbit’s semi-latus rectum has fallen below zero
+- `Decayed` - Orbit has decayed: the computed position is underground
 
 ## Exposed Functions
 


### PR DESCRIPTION
This modifies only `README.md` file in a way for most of the users to get to the most important details faster and makes it a bit more concise. The suggested structure is:
1. Introduction
2. Installation, sample usage
3. Resources
4. Exported objects and functions
5. Contributing, building
6. Acknowledgements, license

Also removes broken Travis badge and Gitter chat (it's easier to keep track of questions/problems in Github Issues than there)