### PR TITLE
fix: json2satrec - parse EPOCH ending with Z

### DIFF
--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -153,11 +153,11 @@ export interface OMMJsonObjectV3 {
   CCSDS_OMM_VERS?: StartsWith<'3.'>;
   COMMENT?: string;
   CLASSIFICATION?: string;
-  OBJECT_NAME?: string;
+  OBJECT_NAME: string;
   /**
    * Recommended, but not required, to be an International spacecraft designator.
    */
-  OBJECT_ID?: string;
+  OBJECT_ID: string;
   /**
    * NOTE: This is required field in OMM spec, but Celestrak omits it, so we make it optional.
    * If present, it is restricted to only the value this library supports.

--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -153,11 +153,11 @@ export interface OMMJsonObjectV3 {
   CCSDS_OMM_VERS?: StartsWith<'3.'>;
   COMMENT?: string;
   CLASSIFICATION?: string;
-  OBJECT_NAME: string;
+  OBJECT_NAME?: string;
   /**
    * Recommended, but not required, to be an International spacecraft designator.
    */
-  OBJECT_ID: string;
+  OBJECT_ID?: string;
   /**
    * NOTE: This is required field in OMM spec, but Celestrak omits it, so we make it optional.
    * If present, it is restricted to only the value this library supports.
@@ -169,7 +169,7 @@ export interface OMMJsonObjectV3 {
    * SGP ephemeris type.
    */
   REF_FRAME?: 'TEME';
-  
+
   /**
    * NOTE: This is required field in OMM spec, but Celestrak omits it, so we make it optional
    */
@@ -228,7 +228,7 @@ export interface OMMJsonObjectV3 {
 
   NORAD_CAT_ID: string | number;
   ELEMENT_SET_NO: string | number;
-  REV_AT_EPOCH: string | number;
+  REV_AT_EPOCH?: string | number;
   BSTAR: string | number;
   MEAN_MOTION_DOT: string | number;
   MEAN_MOTION_DDOT: string | number;

--- a/src/io.ts
+++ b/src/io.ts
@@ -184,12 +184,12 @@ export function twoline2satrec(longstr1: string, longstr2: string) {
  *  references    :
  *    https://celestrak.org/NORAD/documentation/gp-data-formats.php
  --------------------------------------------------------------------------- */
-export function json2satrec(jsonobj: OMMJsonObject & { EPOCH: number | string }, opsmode: 'a' | 'i' = 'i') {
+export function json2satrec(jsonobj: OMMJsonObject, opsmode: 'a' | 'i' = 'i') {
   const error = 0;
 
   const satnum = jsonobj.NORAD_CAT_ID.toString();
 
-  const epoch = new Date(typeof jsonobj.EPOCH === 'number' ? jsonobj.EPOCH : jsonobj.EPOCH + (jsonobj.EPOCH.endsWith('Z') ? '' : 'Z'));
+  const epoch = new Date(jsonobj.EPOCH.endsWith('Z') ? jsonobj.EPOCH : jsonobj.EPOCH + 'Z');
   const year = epoch.getUTCFullYear();
 
   const epochyr = Number(year.toString().slice(-2));

--- a/src/io.ts
+++ b/src/io.ts
@@ -184,12 +184,12 @@ export function twoline2satrec(longstr1: string, longstr2: string) {
  *  references    :
  *    https://celestrak.org/NORAD/documentation/gp-data-formats.php
  --------------------------------------------------------------------------- */
-export function json2satrec(jsonobj: OMMJsonObject, opsmode: 'a' | 'i' = 'i') {
+export function json2satrec(jsonobj: OMMJsonObject & { EPOCH: number | string }, opsmode: 'a' | 'i' = 'i') {
   const error = 0;
 
   const satnum = jsonobj.NORAD_CAT_ID.toString();
 
-  const epoch = new Date(jsonobj.EPOCH + 'Z');
+  const epoch = new Date(typeof jsonobj.EPOCH === 'number' ? jsonobj.EPOCH : jsonobj.EPOCH + (jsonobj.EPOCH.endsWith('Z') ? '' : 'Z'));
   const year = epoch.getUTCFullYear();
 
   const epochyr = Number(year.toString().slice(-2));


### PR DESCRIPTION
This PR fixes an issue where `json2satrec` is not able to parse EPOCH strings that end with Z.
While most OMM providers tend to omit the trailing Z from their EPOCHs, the OMM standard does allow a trailing Z and most dates produces by JS software do end with Z by default (ie: `new Date().toISOString()`).

This PR also marks `REV_AT_EPOCH` as optional since its not required by the spec.

`OMMJsonObject` type changes:

* make REV_AT_EPOCH optional (not required by the spec and not used in any calculations)

`json2satrec` function changes:

* correctly parse EPOCH that ends with "Z"

<hr>

<s>
This PR aims to make `json2satrec` less strict about the properties it requires to function and also compatible with alternative epoch formats.

type changes:

* make OBJECT_NAME optional (not used in any calculations)
* make OBJECT_ID optional (not used in any calculations)
* make REV_AT_EPOCH optional (not used in any calculations)

function changes:

* make EPOCH also accept milliseconds and ISO string that already ends with "Z" (actual type unchanged)
</s>