### PR TITLE
Add unit tests for sunPos and shadowFraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Test: Add unit tests for `sunPos` and `shadowFraction`.
+
 ## 7.0.1 (2026-05-15)
 
 - Fix: `propagate` function did not have a `null` return type in its overloads.

--- a/test/__snapshots__/sun.test.ts.snap
+++ b/test/__snapshots__/sun.test.ts.snap
@@ -1,0 +1,13 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`sunPos > matches regression snapshot 1`] = `
+{
+  "decl": 0.2170123537803032,
+  "rsun": {
+    "x": -0.8545661523941536,
+    "y": 0.5048341405234656,
+    "z": 0.21884022102969627,
+  },
+  "rtasc": 2.6080030935832834,
+}
+`;

--- a/test/shadow.test.ts
+++ b/test/shadow.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import goodData from './io.json' with { type: 'json' };
+import { sunPos } from '../src/sun.js';
+import { shadowFraction } from '../src/shadow.js';
+import { jday } from '../src/ext.js';
+import { twoline2satrec } from '../src/io.js';
+import { propagate } from '../src/propagation.js';
+
+const numDigits = 8;
+
+const iss = goodData[0]!;
+const issSatrec = twoline2satrec(iss.tleLine1, iss.tleLine2);
+
+function shadowFractionAt(isoDate: string): number {
+  const date = new Date(isoDate);
+  const state = propagate(issSatrec, date);
+  expect(state).not.toBeNull();
+  const { rsun } = sunPos(jday(date));
+  return shadowFraction(rsun, state!.position);
+}
+
+describe('shadowFraction', () => {
+  it('returns 0 for a sun-lit ISS position from io.json', () => {
+    expect(shadowFractionAt(`${iss.EPOCH}Z`)).toBe(0);
+  });
+
+  it('returns 1 for an ISS position in umbra', () => {
+    expect(shadowFractionAt('2023-08-19T13:25:27.896Z')).toBe(1);
+  });
+
+  it('returns a value between 0 and 1 in penumbra', () => {
+    const fraction = shadowFractionAt('2023-08-22T01:25:27.896Z');
+
+    expect(fraction).toBeGreaterThan(0);
+    expect(fraction).toBeLessThan(1);
+    expect(fraction).toBeCloseTo(0.5148640536131047, numDigits);
+  });
+
+  it('integrates propagate, sunPos, and shadowFraction for ISS', () => {
+    const date = new Date(`${iss.EPOCH}Z`);
+    const state = propagate(issSatrec, date);
+    expect(state).not.toBeNull();
+
+    const { rsun } = sunPos(jday(date));
+    const fraction = shadowFraction(rsun, state!.position);
+
+    expect(fraction).toBe(0);
+  });
+});

--- a/test/sun.test.ts
+++ b/test/sun.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import goodData from './io.json' with { type: 'json' };
+import { sunPos } from '../src/sun.js';
+import { jday } from '../src/ext.js';
+
+const numDigits = 8;
+const mockData = goodData[0]!;
+const regressionDate = new Date(`${mockData.EPOCH}Z`);
+
+function rsunMagnitude(rsun: { x: number; y: number; z: number }): number {
+  return Math.sqrt(rsun.x * rsun.x + rsun.y * rsun.y + rsun.z * rsun.z);
+}
+
+describe('sunPos', () => {
+  it('returns a sun vector with magnitude close to 1 AU', () => {
+    const { rsun } = sunPos(jday(regressionDate));
+    // Vallado low-precision model includes orbital eccentricity (~0.98–1.02 AU).
+    expect(rsunMagnitude(rsun)).toBeCloseTo(1, 1);
+  });
+
+  it('gives the same result for jday(Date) and jday(components)', () => {
+    const date = regressionDate;
+    const fromDate = sunPos(jday(date));
+    const fromComponents = sunPos(jday(
+      date.getUTCFullYear(),
+      date.getUTCMonth() + 1,
+      date.getUTCDate(),
+      date.getUTCHours(),
+      date.getUTCMinutes(),
+      date.getUTCSeconds(),
+      date.getUTCMilliseconds(),
+    ));
+
+    expect(fromComponents.rsun.x).toBeCloseTo(fromDate.rsun.x, numDigits);
+    expect(fromComponents.rsun.y).toBeCloseTo(fromDate.rsun.y, numDigits);
+    expect(fromComponents.rsun.z).toBeCloseTo(fromDate.rsun.z, numDigits);
+    expect(fromComponents.rtasc).toBeCloseTo(fromDate.rtasc, numDigits);
+    expect(fromComponents.decl).toBeCloseTo(fromDate.decl, numDigits);
+  });
+
+  it('matches regression snapshot', () => {
+    const result = sunPos(jday(regressionDate));
+    expect({
+      rsun: {
+        x: result.rsun.x,
+        y: result.rsun.y,
+        z: result.rsun.z,
+      },
+      rtasc: result.rtasc,
+      decl: result.decl,
+    }).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `test/sun.test.ts`: magnitude ~1 AU, jday parity
- Add `test/shadow.test.ts`: lit / umbra / penumbra
- Update CHANGELOG