### PR TITLE
Add sunPos and shadowFraction export checks to index.test.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Test: Add unit tests for `sunPos` and `shadowFraction`.
+- Test: Export checks for `sunPos` and `shadowFraction` in `index.test.ts`.
 
 ## 7.0.1 (2026-05-15)
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -22,6 +22,8 @@ import { twoline2satrec, json2satrec } from '../src/io.js';
 import { propagate, sgp4, gstime } from '../src/propagation.js';
 
 import { dopplerFactor } from '../src/dopplerFactor.js';
+import { sunPos } from '../src/sun.js';
+import { shadowFraction } from '../src/shadow.js';
 
 import {
   radiansToDegrees,
@@ -67,6 +69,8 @@ describe('Library export', () => {
   it('jday', () => expect(es.jday).toEqual(jday));
   it('invjday', () => expect(es.invjday).toEqual(invjday));
   it('dopplerFactor', () => expect(es.dopplerFactor).toEqual(dopplerFactor));
+  it('sunPos', () => expect(es.sunPos).toEqual(sunPos));
+  it('shadowFraction', () => expect(es.shadowFraction).toEqual(shadowFraction));
   it('transforms', () => {
     expect(es.radiansToDegrees).toEqual(radiansToDegrees);
     expect(es.degreesToRadians).toEqual(degreesToRadians);


### PR DESCRIPTION
## Summary
- Assert \`sunPos\` and \`shadowFraction\` are exported from the public API in \`index.test.ts\`
- Update CHANGELOG