### PR TITLE
Exposed mean motion with kozai in `SatRec` as `nokozai`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Test: Add unit tests for `sunPos` and `shadowFraction`.
+- Feature: Exposed mean motion with kozai in `SatRec` as `nokozai`.
 
 ## 7.0.1 (2026-05-15)
 

--- a/src/propagation/SatRec.ts
+++ b/src/propagation/SatRec.ts
@@ -201,7 +201,7 @@ export interface SatRec {
    */
   mo: number;
   /**
-   * Mean motion in radians per minute.
+   * Mean motion in radians per minute without kozai.
    */
   no: number;
   /**

--- a/src/propagation/SatRec.ts
+++ b/src/propagation/SatRec.ts
@@ -204,6 +204,10 @@ export interface SatRec {
    * Mean motion in radians per minute.
    */
   no: number;
+  /**
+   * Mean motion in radians per minute with kozai.
+   */
+  nokozai: number;
 
   // sgp4fix add unkozai'd variable
   // not used by the library

--- a/src/propagation/sgp4init.ts
+++ b/src/propagation/sgp4init.ts
@@ -234,6 +234,7 @@ export function sgp4init(
   satrec.inclo = xinclo;
   satrec.mo = xmo;
   satrec.no = xno;
+  satrec.nokozai = xno;
   satrec.nodeo = xnodeo;
 
   //  sgp4fix add opsmode

--- a/test/io.test.ts
+++ b/test/io.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
-  twoline2satrec, json2satrec, OMMJsonObject, SatRec,
+  twoline2satrec, json2satrec, OMMJsonObject, SatRec, constants
 } from '../src/index.js';
 import badTleData from './io-edge.json' with { type: 'json' };
 import goodData from './io.json' with { type: 'json' };
@@ -74,6 +74,6 @@ describe('mean motion', () => {
     const satrec = twoline2satrec(tle1, tle2);
     expect(satrec.no).toBeCloseTo(0.06428212791307905, 10);
     expect(satrec.nokozai).toBeCloseTo(0.06429242548587555, 10);
-    expect(satrec.nokozai * rad2deg * 4).toBeCloseTo(14.73473854, 10);
+    expect(satrec.nokozai * constants.rad2deg * 4).toBeCloseTo(14.73473854, 10);
   });
 });

--- a/test/io.test.ts
+++ b/test/io.test.ts
@@ -66,3 +66,14 @@ describe('twoline2satrec', () => {
     expect(satrec.ecco).toBeCloseTo(0.0000123, 10);
   });
 });
+
+describe('mean motion', () => {
+  it('should be stored with and without kozai', () => {
+    const tle1 = `1 99999U 25999A   25274.00000000 -.00000000  00000-0  00000-0 0    14`;
+    const tle2 = `2 99999  50.0000 142.8988     123 180.0001 210.9293 14.73473854000071`;
+    const satrec = twoline2satrec(tle1, tle2);
+    expect(satrec.no).toBeCloseTo(0.06428212791307905, 10);
+    expect(satrec.nokozai).toBeCloseTo(0.06429242548587555, 10);
+    expect(satrec.nokozai * rad2deg * 4).toBeCloseTo(14.73473854, 10);
+  });
+});


### PR DESCRIPTION
The `SatRec` class now stores mean motion with and without kozai, `satrec.no` and `satrec.nokozai` respectively. This is to enable access to the kozai version in javascript / typescript without having to manually parse the TLE or manually read the OMM data. Like `satrec.no`, `satrec.nokozai` is not meant to be modified after the `SatRec` is constructed.

Closes #170.