### PR TITLE
Fix invjday losing a whole second to truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Fix: `invjday` truncated the fractional second instead of rounding it, so `invjday(jday(date))` came back a full second early for about half of all inputs that fall exactly on a second, and the array overload could report `sec = -1`. `invjday` now keeps millisecond precision, which also makes it a true inverse of `jday` for dates carrying milliseconds (#75).
+- Test: deterministic `jday`/`invjday` round-trip tests over second, minute, midnight and month/year boundaries.
+
 ## 7.1.0 (2026-07-23)
 
 - Feature: add `checkForDecay` function that allows filtering satellites decayed long ago but for which SGP4 reports "successful" propagation with garbage positions (see [section in the docs](https://shashwatak.github.io/satellite-js/docs/propagation/community-decay-check)).

--- a/src/ext.ts
+++ b/src/ext.ts
@@ -245,11 +245,22 @@ export function invjday(jd: JDay, asArray?: boolean) {
 
   const { mon, day, hr, minute } = mdhms;
 
-  const sec = mdhms.sec - 0.000000864;
+  // A julian date near 2.45e6 has an ulp of ~40 us, so `sec` lands just under
+  // the true integer about half the time and truncating it drops a whole
+  // second. Round to the nearest millisecond and let Date.UTC carry 60000 ms.
+  const ms = Math.round(mdhms.sec * 1000);
+  const date = new Date(Date.UTC(year, mon - 1, day, hr, minute, 0, ms));
 
   if (asArray) {
-    return [year, mon, day, hr, minute, Math.floor(sec)];
+    return [
+      date.getUTCFullYear(),
+      date.getUTCMonth() + 1,
+      date.getUTCDate(),
+      date.getUTCHours(),
+      date.getUTCMinutes(),
+      date.getUTCSeconds(),
+    ];
   }
 
-  return new Date(Date.UTC(year, mon - 1, day, hr, minute, Math.floor(sec)));
+  return date;
 }

--- a/test/ext.test.ts
+++ b/test/ext.test.ts
@@ -92,8 +92,99 @@ describe('Julian date / time', () => {
 
     it('date to jday and inverse conversion', () => {
       const jd = jday(now);
-      const expected = (now.getTime() - now.getMilliseconds()) / 1000;
-      expect((invjday(jd) as Date).getTime() / 1000).toEqual(expected);
+      expect((invjday(jd) as Date).getTime()).toEqual(now.getTime());
+    });
+  });
+
+  describe('jday & invjday round trip', () => {
+    const roundTrip = (date: Date) =>
+      (invjday(jday(date)) as Date).getTime() - date.getTime();
+
+    const sweep = (from: number, step: number, count: number) => {
+      const failures: string[] = [];
+      for (let i = 0; i < count; i += 1) {
+        const date = new Date(from + i * step);
+        const delta = roundTrip(date);
+        if (delta !== 0)
+          failures.push(`${date.toISOString()} off by ${delta} ms`);
+      }
+      return failures.slice(0, 5);
+    };
+
+    // A julian date near 2.45e6 resolves only ~40 us, so the recovered second
+    // lands just under the true integer about half the time. These three sweeps
+    // are the inputs that used to lose a whole second to Math.floor.
+    it('round trips instants falling exactly on a second', () => {
+      expect(sweep(Date.UTC(2000, 0, 1), 61_000, 20_000)).toEqual([]);
+    });
+
+    it('round trips instants falling exactly on a minute', () => {
+      expect(sweep(Date.UTC(2015, 5, 15), 60_000, 20_000)).toEqual([]);
+    });
+
+    it('round trips midnight', () => {
+      expect(sweep(Date.UTC(1990, 0, 1), 86_400_000, 20_000)).toEqual([]);
+    });
+
+    it('round trips month, year and leap-day boundaries', () => {
+      const failures: string[] = [];
+      for (const year of [1958, 1972, 1999, 2000, 2001, 2004, 2024, 2100]) {
+        for (let month = 0; month < 12; month += 1) {
+          const first = Date.UTC(year, month, 1);
+          for (const t of [first - 1000, first, first + 1000]) {
+            const delta = roundTrip(new Date(t));
+            if (delta !== 0)
+              failures.push(`${new Date(t).toISOString()} off by ${delta} ms`);
+          }
+        }
+      }
+      expect(failures).toEqual([]);
+    });
+
+    it('keeps milliseconds', () => {
+      for (const iso of [
+        '2018-01-01T05:30:30.123Z',
+        '2000-01-01T00:00:00.001Z',
+        '2024-02-29T23:59:59.999Z',
+        '1969-07-20T20:17:40.500Z',
+      ]) {
+        const date = new Date(iso);
+        expect((invjday(jday(date)) as Date).toISOString()).toEqual(iso);
+      }
+    });
+
+    it('array overload stays within the documented second range', () => {
+      // Math.floor(sec - 8.64e-7) returned -1 whenever the residual went
+      // slightly negative, which is outside the documented 0..59.999 range.
+      const outOfRange: number[][] = [];
+      for (let i = 0; i < 20_000; i += 1) {
+        const parts = invjday(
+          jday(new Date(Date.UTC(2000, 0, 8) + i * 60_000)),
+          true,
+        );
+        if (parts[5] < 0 || parts[5] > 59) outOfRange.push([...parts]);
+      }
+      expect(outOfRange.slice(0, 5)).toEqual([]);
+    });
+
+    it('array overload agrees with the date overload', () => {
+      const disagreements: string[] = [];
+      for (let i = 0; i < 20_000; i += 1) {
+        const jd = jday(new Date(Date.UTC(2000, 0, 1) + i * 60_000));
+        const date = invjday(jd);
+        const parts = invjday(jd, true);
+        const asDate = [
+          date.getUTCFullYear(),
+          date.getUTCMonth() + 1,
+          date.getUTCDate(),
+          date.getUTCHours(),
+          date.getUTCMinutes(),
+          date.getUTCSeconds(),
+        ];
+        if (asDate.join() !== parts.join())
+          disagreements.push(`${asDate.join()} vs ${parts.join()}`);
+      }
+      expect(disagreements.slice(0, 5)).toEqual([]);
     });
   });
 


### PR DESCRIPTION
`invjday(jday(date))` comes back a full second early for about half of all instants that fall exactly on a second (99937/200000 in a sweep from 2000-01-01, worst case -1000 ms): a julian date near 2.45e6 has an ulp of ~40 µs, so `days2mdhms` hands back e.g. `sec = 59.9999964` and `Math.floor` throws away a whole second instead of 40 µs. Vallado's compensating nudge is 0.864 µs — 46× smaller than the ulp it has to overcome, so it never fires (the same idiom in `initl.ts` nudges by 1e-8 day, 21.5× the ulp, and is fine). Rounding into the millisecond slot of `Date.UTC` fixes it and lets a rounded-up 60000 ms carry into the minute/hour/day, which also removes the array overload's out-of-range `sec = -1` (0.64% of exact-minute inputs) and makes `invjday` a true inverse for dates carrying milliseconds — #75, which #38 only fixed on the `jday` side.

Same cause explains the "reason for this is not clear (PRs welcome)" note on `invjdayFull` in `sgp4Catalog.test.ts`: `Date.UTC` truncates its millisecond argument too, so `(sec % 1) * 1000 = 999.996` becomes `999` and it lands 1 ms short on 50008/100000 inputs. I left that helper and the catalog test alone.

Checked against exact-rational ground truth over 600k instants (0 mismatches after, ~50% before); the `js` project is 409 passing and `lint`/`test:types` are clean. I couldn't run the `wasm_*` and `catalog` projects locally (no Emscripten here, and `sgp4CatalogResults.json` trips V8's max string length) — but nothing in `src/` calls `invjday`, and propagating all 25974 satellites in `tle.txt` at four offsets gives an identical SHA-256 digest before and after, so the SGP4 path is untouched. One existing test needed correcting: it subtracted the milliseconds from its own expectation, which is what pinned the truncated behaviour, and seeding it from `new Date()` made the failing input class unreachable.
