### PR TITLE
fix(sun): keep right ascension within [0, 2π)

### DIFF
--- a/src/sun.ts
+++ b/src/sun.ts
@@ -79,8 +79,8 @@ export function sunPos(jday: JDay): {
   }
 
   let rtasc = rtasc_raw;
-  if (Math.abs(eclplong_raw - rtasc) > pi * 0.5) {
-    rtasc += 0.5 * pi * Math.round((eclplong_raw - rtasc_raw) / (0.5 * pi));
+  if (Math.abs(eclplong - rtasc) > pi * 0.5) {
+    rtasc += 0.5 * pi * Math.round((eclplong - rtasc_raw) / (0.5 * pi));
   }
 
   const decl = Math.asin(Math.sin(obliquity) * Math.sin(eclplong_raw));

--- a/test/sun.test.ts
+++ b/test/sun.test.ts
@@ -105,6 +105,16 @@ describe('sunPos orbital geometry', () => {
     expect(dayOfYear).toBeLessThanOrEqual(190);
   });
 
+  it.each(years)('keeps right ascension within [0, 2π) (%i)', (year) => {
+    // A quadrant-check bug returned rtasc shifted by -2π (outside [0, 2π)) for
+    // dates whose ecliptic longitude was negative, e.g. pre-2000.
+    for (let month = 1; month <= 12; month++) {
+      const { rtasc } = sunPos(jday(year, month, 15, 0, 0, 0));
+      expect(rtasc).toBeGreaterThanOrEqual(0);
+      expect(rtasc).toBeLessThan(2 * Math.PI);
+    }
+  });
+
   it('reproduces the Earth-Sun distance at the J2000.0 epoch', () => {
     // 2000-01-01 12:00 UT is a few days after perihelion, so the Sun is near
     // its closest: 0.9833 AU.


### PR DESCRIPTION
### Bug

`sunPos` computes a non-negative `eclplong` for the quadrant check (`src/sun.ts:76-79`), but the check itself still reads the raw, possibly-negative `eclplong_raw`:

```ts
let rtasc = rtasc_raw;
if (Math.abs(eclplong_raw - rtasc) > pi * 0.5) {          // <- eclplong_raw
  rtasc += 0.5 * pi * Math.round((eclplong_raw - rtasc_raw) / (0.5 * pi));  // <- eclplong_raw
}
```

The Vallado reference quoted right below the function reassigns `eclplong_raw` to its non-negative value *before* the check, so `eclplong` was clearly meant to be used here. As written, `eclplong_raw` is effectively a dead variable in that branch, and for dates whose ecliptic longitude is negative (e.g. pre-2000) `rtasc` comes back shifted by −2π, outside [0, 2π). `rsun` and `decl` are unaffected (sin/cos are 2π-periodic), which is why it went unnoticed.

### Reproduced locally

`sunPos(jday(...)).rtasc`:

| date | before | after |
|---|---|---|
| 1975-06-15 | **−4.839918** | 1.443267 |
| 1985-03-01 | **−0.316561** | 5.966625 |
| 1995-11-20 | **−2.183480** | 4.099705 |
| 2005-06-15 | 1.456887 | 1.456887 |

Before, pre-2000 dates are a full −2π out of range; after, all land in [0, 2π) and post-2000 is unchanged.

### Fix

Use `eclplong` (the non-negative value) in the quadrant check, matching the reference. Added a regression test asserting `rtasc ∈ [0, 2π)` across the documented 1950–2050 window; it fails on the current code (a 1950 date returns −1.11) and passes with the fix. The full JS test project (406 tests) and `test:types` pass.

*Written with AI assistance; I've reviewed and tested the change and will maintain it.*
